### PR TITLE
add virtual destructor to BaseMultiParms class

### DIFF
--- a/test/prototype_factory_test.cpp
+++ b/test/prototype_factory_test.cpp
@@ -58,6 +58,7 @@ public:
   virtual clone_type clone(int a) = 0;
   virtual clone_type clone(int a, int b) = 0;
   virtual int get() = 0;
+  virtual ~BaseMultiParms() {}
 };
 
 class DerivedSum : public BaseMultiParms {


### PR DESCRIPTION
Hello. I found an error building `modern_wheel` , so I suggest sourse fixes.
Could you check if it is the right fix?

- error
```
     /c++/4.8.5/ext/new_allocator.h:124:29: error: destructor called on non-fina
     l '(anonymous namespace)::DerivedSum' that has virtual functions but non-
     virtual destructor [- Werror,-Wdelete-non-virtual-dtor]
                destroy(_Up* __p) { __p->~_Up(); }
                                    ^

```
All base classes with a virtual function should define a virtual destructor.
So I added virtual destructor to base class.